### PR TITLE
Fix Gravatar image not showing due to Content Security Policy (csp) setting

### DIFF
--- a/MantisKanban.php
+++ b/MantisKanban.php
@@ -1,6 +1,8 @@
 <?php
 
 class MantisKanbanPlugin extends MantisPlugin {
+	const GRAVATAR_URL = 'https://secure.gravatar.com/';
+
     function register() {
         $this->name = 'Mantis Kanban';    # Proper name of plugin
         $this->description = 'A Kanban board view';    # Short description of the plugin
@@ -24,9 +26,14 @@ class MantisKanbanPlugin extends MantisPlugin {
 	    
 	function hooks( ) {
 		$hooks = array(
+			'EVENT_CORE_HEADERS' => 'csp_headers',
 			'EVENT_MENU_MAIN' => 'main_menu'
 		);
 		return $hooks;
+	}
+
+	function csp_headers() {
+		http_csp_add( 'img-src', self::GRAVATAR_URL );
 	}
     
 	

--- a/pages/kanban_page.php
+++ b/pages/kanban_page.php
@@ -19,6 +19,11 @@ require_api( 'bug_api.php' );
 require_api( 'string_api.php' );
 require_api( 'date_api.php' );
 
+function gravatarUrl($email) {
+    $emailHash = hash('sha256',(strtolower(trim($email))));
+    return MantisKanbanPlugin::GRAVATAR_URL . '/avatar/'. $emailHash .'?s=28&d=mm";
+}
+
 auth_ensure_user_authenticated();
 $t_current_user_id = auth_get_current_user_id();
 
@@ -152,9 +157,8 @@ if ( !$t_combined ) {
 			
 					// print username instead of status
 					if(( ON == config_get( 'show_assigned_names' ) ) && ( $t_bug->handler_id > 0 ) && ( access_has_project_level( config_get( 'view_handler_threshold' ), $t_bug->project_id ) ) ) {
-						$emailHash = md5( strtolower( trim( user_get_email($t_bug->handler_id) ) ) );
 						echo '<div class="owner">';
-						echo '<img src="http://www.gravatar.com/avatar/'. $emailHash .'?s=28&d=mm" />'; 
+						echo '<img src="' . gravatarUrl(user_get_email($t_bug->handler_id)) . '"/>';
 						echo prepare_user_name( $t_bug->handler_id );
 						echo '</div>';
 					}
@@ -253,9 +257,8 @@ if ( !$t_combined ) {
 			
 				// print username instead of status
 				if(( ON == config_get( 'show_assigned_names' ) ) && ( $t_bug->handler_id > 0 ) && ( access_has_project_level( config_get( 'view_handler_threshold' ), $t_bug->project_id ) ) ) {
-					$emailHash = md5( strtolower( trim( user_get_email($t_bug->handler_id) ) ) );
 					echo '<div class="owner">';
-					echo '<img src="http://www.gravatar.com/avatar/'. $emailHash .'?s=28&d=mm" />'; 
+					echo '<img src="' . gravatarUrl(user_get_email($t_bug->handler_id)) . '"/>';
 					echo prepare_user_name( $t_bug->handler_id );
 					echo '</div>';
 				}


### PR DESCRIPTION
Content Security Policy prevented image from www.gravatar.com being displayed (serving mantis from a https connection but protocol set was http). Changed the URL to match URL used in the Mantis Gravatar plugin (secure.gravatar.com) and also emit a csp header allowing that URL to be retrieved in case the Mantis Gravatar plugin has not been installed/enabled.